### PR TITLE
Create the Docker Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
         "ghcr.io/devcontainers/features/git:1": {},
         "ghcr.io/devcontainers/features/git-lfs:1": {},
         "ghcr.io/devcontainers/features/github-cli:1": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/devcontainers/features/go:1": {
             "version": "1.25.1"
         },

--- a/.github/workflows/cleanup-pr-images.yml
+++ b/.github/workflows/cleanup-pr-images.yml
@@ -1,0 +1,59 @@
+name: Cleanup PR Container Images
+
+on:
+  pull_request:
+    types: [closed]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: nakedsoftware/time
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      
+    steps:
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Delete PR container images
+      env:
+        PR_NUMBER: ${{ github.event.number }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo "Cleaning up container images for PR #${PR_NUMBER}"
+        
+        # Get all package versions for the image
+        PACKAGE_VERSIONS=$(gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "/orgs/nakedsoftware/packages/container/time/versions" \
+          --jq '.[] | select(.metadata.container.tags[]? | test("^pr-'${PR_NUMBER}'$")) | .id')
+        
+        if [ -n "$PACKAGE_VERSIONS" ]; then
+          echo "Found package versions to delete:"
+          echo "$PACKAGE_VERSIONS"
+          
+          # Delete each version
+          echo "$PACKAGE_VERSIONS" | while read -r version_id; do
+            if [ -n "$version_id" ]; then
+              echo "Deleting package version: $version_id"
+              gh api \
+                --method DELETE \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "/orgs/nakedsoftware/packages/container/time/versions/$version_id" || true
+            fi
+          done
+          
+          echo "Cleanup completed for PR #${PR_NUMBER}"
+        else
+          echo "No container images found for PR #${PR_NUMBER}"
+        fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,7 +84,8 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
-          type=raw,value=latest,enable={{is_default_branch}}
+          type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+          type=raw,value=dev,enable={{is_default_branch}}
 
     - name: Build and push Docker images
       uses: docker/build-push-action@v5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,84 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: nakedsoftware/time
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.25.1'
+        cache: true
+        cache-dependency-path: go.sum
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Build Go binary for linux/amd64
+      env:
+        GOOS: linux
+        GOARCH: amd64
+        CGO_ENABLED: 0
+      run: |
+        mkdir -p out
+        go build -o out/time-amd64 ./cmd/time
+
+    - name: Build Go binary for linux/arm64
+      env:
+        GOOS: linux
+        GOARCH: arm64
+        CGO_ENABLED: 0
+      run: |
+        mkdir -p out
+        go build -o out/time-arm64 ./cmd/time
+
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: ${{ startsWith(github.ref, 'refs/tags/') }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,12 +13,11 @@ env:
   IMAGE_NAME: nakedsoftware/time
 
 jobs:
-  build:
+  build-binaries:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -30,11 +29,44 @@ jobs:
         cache: true
         cache-dependency-path: go.sum
 
+    - name: Build Go binary for linux/${{ matrix.arch }}
+      env:
+        GOOS: linux
+        GOARCH: ${{ matrix.arch }}
+        CGO_ENABLED: 0
+      run: |
+        mkdir -p out
+        go build -o out/time-${{ matrix.arch }} ./cmd/time
+
+    - name: Upload binary artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: binary-${{ matrix.arch }}
+        path: out/time-${{ matrix.arch }}
+        retention-days: 1
+
+  build-docker:
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Download all binary artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: out
+        pattern: binary-*
+        merge-multiple: true
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
     - name: Log in to Container Registry
-      if: github.event_name != 'pull_request'
       uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
@@ -54,31 +86,47 @@ jobs:
           type=semver,pattern={{major}}
           type=raw,value=latest,enable={{is_default_branch}}
 
-    - name: Build Go binary for linux/amd64
-      env:
-        GOOS: linux
-        GOARCH: amd64
-        CGO_ENABLED: 0
-      run: |
-        mkdir -p out
-        go build -o out/time-amd64 ./cmd/time
-
-    - name: Build Go binary for linux/arm64
-      env:
-        GOOS: linux
-        GOARCH: arm64
-        CGO_ENABLED: 0
-      run: |
-        mkdir -p out
-        go build -o out/time-arm64 ./cmd/time
-
     - name: Build and push Docker images
       uses: docker/build-push-action@v5
       with:
         context: .
         platforms: linux/amd64,linux/arm64
-        push: ${{ startsWith(github.ref, 'refs/tags/') }}
+        push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+    - name: Comment on PR with container image info
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const tags = `${{ steps.meta.outputs.tags }}`.split('\n').filter(tag => tag.trim() !== '');
+          const prTag = tags.find(tag => tag.includes('pr-${{ github.event.number }}'));
+          
+          if (prTag) {
+            const comment = `## 🐳 Container Image Built
+            
+            Your PR container image has been built and published:
+            
+            \`\`\`
+            ${prTag}
+            \`\`\`
+            
+            **Supported architectures:** linux/amd64, linux/arm64
+            
+            **Usage:**
+            \`\`\`bash
+            docker run --rm ${prTag} --help
+            \`\`\`
+            
+            > 🗑️ This image will be automatically deleted when the PR is closed.`;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });
+          }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Use distroless base image as base
+FROM gcr.io/distroless/base-debian12:latest
+
+# Create a non-root user
+USER 65534:65534
+
+# Set working directory
+WORKDIR /opt/nakedtime
+
+# Copy the appropriate architecture binary
+ARG TARGETARCH
+COPY --chown=65534:65534 out/time-${TARGETARCH} bin/time
+
+# Set the entrypoint to run the time command
+ENTRYPOINT ["bin/time"]


### PR DESCRIPTION
I used Claude Sonnet 4 to help me to build the Docker container image specification using a distroless image as the base image. This will make the distribution container smaller and reduce the attack surface of the container.

We created a GitHub Actions workflow that will build a multi-architecture Docker container supporting both `linux/amd64` and `linux/arm64` architectures. The Docker container images will be published to the `nakedsoftware` GitHub Packages.