### PR TITLE
Build Naked Time for Microsoft Windows

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,149 @@
+name: Build Windows (Intel & ARM64)
+
+on:
+  repository_dispatch:
+    types: [build-windows-command]
+
+jobs:
+  build:
+    if: github.event.client_payload.slash_command.command == 'build-windows'
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            arch: amd64
+            platform_name: "Intel x64"
+            artifact_suffix: "windows-x64"
+          - os: windows-latest  # Cross-compile ARM64 from x64 runner
+            arch: arm64
+            platform_name: "ARM64"
+            artifact_suffix: "windows-arm64"
+    
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+    - name: Add reaction
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+        reactions: eyes
+    
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.client_payload.pull_request.head.ref }}
+    
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+    
+    - name: Get version info
+      id: version
+      shell: bash
+      run: |
+        # Get the short commit SHA
+        SHORT_SHA=$(echo ${{ github.event.client_payload.pull_request.head.sha }} | cut -c1-7)
+        # Get the PR number
+        PR_NUMBER=${{ github.event.client_payload.pull_request.number }}
+        # Create version string
+        VERSION="pr-${PR_NUMBER}-${SHORT_SHA}"
+        echo "version=${VERSION}" >> $GITHUB_OUTPUT
+        echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
+        echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
+    
+    - name: Build for Windows ${{ matrix.platform_name }}
+      env:
+        GOOS: windows
+        GOARCH: ${{ matrix.arch }}
+        CGO_ENABLED: 0
+      shell: bash
+      run: |
+        mkdir -p dist
+        go build -ldflags="-s -w" -o dist/time-${{ matrix.artifact_suffix }}.exe ./cmd/time
+        
+        # Verify the binary was built correctly
+        ls -la dist/
+        file dist/time-${{ matrix.artifact_suffix }}.exe || echo "file command not available on Windows"
+    
+    - name: Create archive
+      shell: bash
+      run: |
+        cd dist
+        # Use PowerShell to create a ZIP archive on Windows
+        powershell "Compress-Archive -Path 'time-${{ matrix.artifact_suffix }}.exe' -DestinationPath 'time-${{ matrix.artifact_suffix }}-${{ steps.version.outputs.version }}.zip' -Force"
+        ls -la
+    
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: time-${{ matrix.artifact_suffix }}-${{ steps.version.outputs.version }}
+        path: dist/time-${{ matrix.artifact_suffix }}-${{ steps.version.outputs.version }}.zip
+        retention-days: 30
+    
+    - name: Add success reaction
+      if: success()
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+        reactions: rocket
+    
+    - name: Add failure reaction
+      if: failure()
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+        reactions: confused
+
+  summary:
+    if: github.event.client_payload.slash_command.command == 'build-windows' && always()
+    needs: build
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Get version info
+      id: version
+      run: |
+        # Get the short commit SHA
+        SHORT_SHA=$(echo ${{ github.event.client_payload.pull_request.head.sha }} | cut -c1-7)
+        # Get the PR number
+        PR_NUMBER=${{ github.event.client_payload.pull_request.number }}
+        # Create version string
+        VERSION="pr-${PR_NUMBER}-${SHORT_SHA}"
+        echo "version=${VERSION}" >> $GITHUB_OUTPUT
+        echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
+        echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
+    
+    - name: Post build summary
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        issue-number: ${{ github.event.client_payload.pull_request.number }}
+        body: |
+          ## 🪟 Windows Build Summary
+          
+          **Build Details:**
+          - **Version:** `${{ steps.version.outputs.version }}`
+          - **Commit:** `${{ steps.version.outputs.short_sha }}`
+          - **Overall Status:** ${{ needs.build.result == 'success' && '✅ Success' || needs.build.result == 'failure' && '❌ Failed' || '⚠️ Completed with issues' }}
+          
+          **Downloads:**
+          
+          | Platform | Architecture | Download |
+          |----------|-------------|----------|
+          | Windows | Intel x64 | [time-windows-x64-${{ steps.version.outputs.version }}.zip](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
+          | Windows | ARM64 | [time-windows-arm64-${{ steps.version.outputs.version }}.zip](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
+          
+          > **Note:** Click the download links above, then scroll down to the "Artifacts" section to download the builds. Only successful builds will have downloadable artifacts.
+          
+          **Quick Start:**
+          1. Download the appropriate ZIP file for your Windows architecture
+          2. Extract the ZIP file  
+          3. Run `time-windows-x64.exe --help` or `time-windows-arm64.exe --help`
+          
+          ${{ needs.build.result == 'failure' && '**⚠️ Some builds failed.** Check the [workflow run](' || '' }}${{ needs.build.result == 'failure' && github.server_url || '' }}${{ needs.build.result == 'failure' && '/' || '' }}${{ needs.build.result == 'failure' && github.repository || '' }}${{ needs.build.result == 'failure' && '/actions/runs/' || '' }}${{ needs.build.result == 'failure' && github.run_id || '' }}${{ needs.build.result == 'failure' && ') for details.' || '' }}
+          
+          ---
+          *Builds triggered by `/build-windows` command*

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -8,7 +8,8 @@ jobs:
   slashCommandDispatch:
     if: >
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/build-macos')
+      (contains(github.event.comment.body, '/build-macos') ||
+       contains(github.event.comment.body, '/build-windows'))
     runs-on: ubuntu-latest
     steps:
       - name: Slash Command Dispatch
@@ -17,6 +18,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commands: |
             build-macos
+            build-windows
           permission: write
           issue-type: pull-request
           repository: ${{ github.repository }}


### PR DESCRIPTION
I created a GitHub Actions workflow that will build Naked Time for Microsoft Windows on both Intel x64 and ARM64 architectures. The build will be triggered with the /build-windows slash command.

Closes #18 