### PR TITLE
Add an Activity to the Activity Inventory

### DIFF
--- a/internal/cli/activity_command.go
+++ b/internal/cli/activity_command.go
@@ -90,23 +90,24 @@
 // By using the Software, you acknowledge that you have read this Agreement,
 // understand it, and agree to be bound by its terms and conditions.
 
-package database
+package cli
 
-import (
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
-)
+import "github.com/spf13/cobra"
 
-func NewDB(path string) (*gorm.DB, error) {
-	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{})
-	if err != nil {
-		return nil, err
-	}
-
-	err = db.AutoMigrate(&Pomodoro{}, &Activity{})
-	if err != nil {
-		return nil, err
-	}
-
-	return db, nil
+var activityCommand = &cobra.Command{
+	Use:   "activity",
+	Short: "Manage the Activity Inventory",
+	Long: `
+The activity command provides subcommands for managing activities in the
+Activity Inventory. The Activity Inventory is the collection of all activities
+that have either been assigned to you or you assigned to yourself to complete.
+The Activity Inventory tracks the activities, allows you to review and
+prioritize the activities, and helps you to visualize all of the work that
+you need to complete. When you work on the activities, you will do so using
+pomodoros to track the amount of time you spend working on each activity and
+the type of work you performed to complete each activity.
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Usage()
+	},
 }

--- a/internal/cli/add_activity_command.go
+++ b/internal/cli/add_activity_command.go
@@ -92,6 +92,41 @@
 
 package cli
 
-type contextKey string
+import (
+	"math"
 
-const databaseContextKey contextKey = "db"
+	"github.com/google/uuid"
+	"github.com/nakedsoftware/time/internal/database"
+	"github.com/spf13/cobra"
+	"gorm.io/gorm"
+)
+
+var addActivityCommand = &cobra.Command{
+	Use:   "add title",
+	Short: "Add an activity to the Activity Inventory",
+	Long: `
+The activity add command adds an activity to the Activity Inventory. The
+activity is more a reminder of work that you need to perform either for a
+project or an important task that you want to complete.
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		db := getDB(cmd)
+
+		title := args[0]
+		id, err := uuid.NewV7()
+		if err != nil {
+			return err
+		}
+
+		activity := &database.Activity{
+			Model: database.Model{
+				ID: id,
+			},
+			Title:     title,
+			Priority:  math.MaxInt,
+			Completed: false,
+		}
+		return gorm.G[database.Activity](db).Create(cmd.Context(), activity)
+	},
+}

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -90,23 +90,17 @@
 // By using the Software, you acknowledge that you have read this Agreement,
 // understand it, and agree to be bound by its terms and conditions.
 
-package database
+package cli
 
 import (
-	"gorm.io/driver/sqlite"
+	"github.com/spf13/cobra"
 	"gorm.io/gorm"
 )
 
-func NewDB(path string) (*gorm.DB, error) {
-	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{})
-	if err != nil {
-		return nil, err
-	}
+type contextKey string
 
-	err = db.AutoMigrate(&Pomodoro{}, &Activity{})
-	if err != nil {
-		return nil, err
-	}
+const databaseContextKey contextKey = "db"
 
-	return db, nil
+func getDB(cmd *cobra.Command) *gorm.DB {
+	return cmd.Context().Value(databaseContextKey).(*gorm.DB)
 }

--- a/internal/cli/execute.go
+++ b/internal/cli/execute.go
@@ -104,3 +104,12 @@ import "context"
 func Execute(ctx context.Context) error {
 	return rootCommand.ExecuteContext(ctx)
 }
+
+func init() {
+	rootCommand.AddCommand(activityCommand)
+	rootCommand.AddCommand(pomodoroCommand)
+
+	activityCommand.AddCommand(addActivityCommand)
+
+	pomodoroCommand.AddCommand(startPomodoroCommand)
+}

--- a/internal/cli/pomodoro_command.go
+++ b/internal/cli/pomodoro_command.go
@@ -90,23 +90,22 @@
 // By using the Software, you acknowledge that you have read this Agreement,
 // understand it, and agree to be bound by its terms and conditions.
 
-package database
+package cli
 
-import (
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
-)
+import "github.com/spf13/cobra"
 
-func NewDB(path string) (*gorm.DB, error) {
-	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{})
-	if err != nil {
-		return nil, err
-	}
-
-	err = db.AutoMigrate(&Pomodoro{}, &Activity{})
-	if err != nil {
-		return nil, err
-	}
-
-	return db, nil
+var pomodoroCommand = &cobra.Command{
+	Use:   "pomodoro",
+	Short: "Manage pomodoros",
+	Long: `
+The pomodoros command provides subcommands for performing and managing
+pomodoros. A pomodoro is a 25 minute block of time where you can focus on
+completing an activity that you are working on. By breaking up your work
+into pomodoros, you can focus in shorter increments with small breaks between
+each increment, track your progress, and monitor and improve your efficiency
+in how you complete activities.
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Usage()
+	},
 }

--- a/internal/cli/root_command.go
+++ b/internal/cli/root_command.go
@@ -94,17 +94,11 @@ package cli
 
 import (
 	"context"
-	"database/sql"
-	"fmt"
 	"os"
 	"path"
-	"time"
 
-	"github.com/google/uuid"
 	"github.com/nakedsoftware/time/internal/database"
-	"github.com/nakedsoftware/time/internal/pomodoro"
 	"github.com/spf13/cobra"
-	"gorm.io/gorm"
 )
 
 var rootCommand = &cobra.Command{
@@ -122,89 +116,32 @@ activities, and analyzing if you are using your time effectively or can make
 improvements in your estimation and time management skills.
 `,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		homePath, err := os.UserHomeDir()
-		if err != nil {
-			return err
-		}
-
-		dbDir := path.Join(homePath, ".nakedtime")
-		dbPath := path.Join(dbDir, "time.db")
-		if err := os.MkdirAll(dbDir, 0755); err != nil {
-			return err
-		}
-
-		db, err := database.NewDB(dbPath)
-		if err != nil {
-			return err
-		}
-
-		ctx := context.WithValue(cmd.Context(), databaseContextKey, db)
-		cmd.SetContext(ctx)
-
-		return nil
+		return createDatabase(cmd)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		db := cmd.Context().Value(databaseContextKey).(*gorm.DB)
-		id, err := startPomodoro(cmd.Context(), db)
-		if err != nil {
-			return err
-		}
-
-		completed, err := pomodoro.Run(cmd.Context())
-		if err != nil {
-			return err
-		}
-
-		return endPomodoro(cmd.Context(), db, id, completed)
+		return cmd.Usage()
 	},
 }
 
-func startPomodoro(
-	ctx context.Context,
-	db *gorm.DB,
-) (uuid.UUID, error) {
-	id, err := uuid.NewV7()
-	if err != nil {
-		return id, err
-	}
-
-	p := &database.Pomodoro{
-		Model: database.Model{
-			ID: id,
-		},
-		StartTime: time.Now(),
-	}
-	err = gorm.G[database.Pomodoro](db).Create(ctx, p)
-	return id, err
-}
-
-func endPomodoro(
-	ctx context.Context,
-	db *gorm.DB,
-	id uuid.UUID,
-	completed bool,
-) error {
-	rowsAffected, err := gorm.G[database.Pomodoro](db).
-		Where("id = ?", id).
-		Updates(
-			ctx,
-			database.Pomodoro{
-				EndTime: sql.NullTime{
-					Time:  time.Now(),
-					Valid: true,
-				},
-				Completed: completed,
-			},
-		)
+func createDatabase(cmd *cobra.Command) error {
+	homePath, err := os.UserHomeDir()
 	if err != nil {
 		return err
 	}
 
-	if rowsAffected == 0 {
-		return fmt.Errorf(
-			"pomodoro not found in the database to be closed",
-		)
+	dbDir := path.Join(homePath, ".nakedtime")
+	dbPath := path.Join(dbDir, "time.db")
+	if err := os.MkdirAll(dbDir, 0755); err != nil {
+		return err
 	}
+
+	db, err := database.NewDB(dbPath)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.WithValue(cmd.Context(), databaseContextKey, db)
+	cmd.SetContext(ctx)
 
 	return nil
 }

--- a/internal/database/activity.go
+++ b/internal/database/activity.go
@@ -92,21 +92,10 @@
 
 package database
 
-import (
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
-)
+type Activity struct {
+	Model
 
-func NewDB(path string) (*gorm.DB, error) {
-	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{})
-	if err != nil {
-		return nil, err
-	}
-
-	err = db.AutoMigrate(&Pomodoro{}, &Activity{})
-	if err != nil {
-		return nil, err
-	}
-
-	return db, nil
+	Title     string
+	Priority  int
+	Completed bool
 }


### PR DESCRIPTION
I implemented the command that allows the user to add activities to the Activitiy Inventory. I created the Activity model that will store information about the activity in the SQLite database.

I refactored the pomodoro command to run using the `pomodoro start` command.

Closes #6 