### PR TITLE
Fix Pomodoro Alarm Playback Error

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -3,6 +3,7 @@ name: Build macOS (ARM64)
 on:
   repository_dispatch:
     types: [build-macos-command]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -17,11 +18,12 @@ jobs:
         reactions: eyes
     
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
         ref: ${{ github.event.client_payload.pull_request.head.ref }}
+        lfs: true
     
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -3,6 +3,7 @@ name: Build Windows (Intel & ARM64)
 on:
   repository_dispatch:
     types: [build-windows-command]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -29,11 +30,12 @@ jobs:
         reactions: eyes
     
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
         ref: ${{ github.event.client_payload.pull_request.head.ref }}
+        lfs: true
     
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,9 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
+      with:
+        lfs: true
 
     - name: Set up Go
       uses: actions/setup-go@v4


### PR DESCRIPTION
I updated the actions/checkout GitHub Action to v5 for the macOS, Windows, and Docker container GitHub Actions workflows. I also enabled the flag to download Git LFS files. I think this is the cause of the error that I am seeing where the alert sound is not playing when the pomodoro is complete because the audio file is not being downloaded from LFS.

Closes #37 