### PR TITLE
Link a Pomodoro to an Activity

### DIFF
--- a/internal/cli/activity/add_command.go
+++ b/internal/cli/activity/add_command.go
@@ -93,6 +93,7 @@
 package activity
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/google/uuid"
@@ -128,6 +129,13 @@ project or an important task that you want to complete.
 			Priority:  math.MaxInt,
 			Completed: false,
 		}
-		return gorm.G[database.Activity](db).Create(cmd.Context(), activity)
+		err = gorm.G[database.Activity](db).Create(cmd.Context(), activity)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("%s\n", id.String())
+
+		return nil
 	},
 }

--- a/internal/cli/pomodoro/start_command.go
+++ b/internal/cli/pomodoro/start_command.go
@@ -186,13 +186,13 @@ func readActivityID(ctx context.Context) (string, error) {
 
 	case err := <-errChan:
 		if err == io.EOF {
-			return "", fmt.Errorf("the activity ID for the pomodoro is required")
+			return "", fmt.Errorf("no input provided for activity ID (EOF)")
 		}
 
 		return "", err
 
 	case <-ctx.Done():
-		return "", fmt.Errorf("the activity ID for the pomodoro is required")
+		return "", fmt.Errorf("timed out waiting for activity ID input")
 	}
 }
 

--- a/internal/cli/pomodoro/start_command.go
+++ b/internal/cli/pomodoro/start_command.go
@@ -161,7 +161,7 @@ func readActivityID(ctx context.Context) (string, error) {
 	// timeout context is used to avoid blocking indefinitely if no data is
 	// available on stdin.
 
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 
 	done := make(chan string, 1)

--- a/internal/cli/pomodoro/start_command.go
+++ b/internal/cli/pomodoro/start_command.go
@@ -161,7 +161,8 @@ func readActivityID(ctx context.Context) (string, error) {
 	// timeout context is used to avoid blocking indefinitely if no data is
 	// available on stdin.
 
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	const timeout = 1 * time.Second
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	done := make(chan string, 1)

--- a/internal/database/activity.go
+++ b/internal/database/activity.go
@@ -98,4 +98,5 @@ type Activity struct {
 	Title     string
 	Priority  int
 	Completed bool
+	Pomodoros []Pomodoro
 }

--- a/internal/database/pomodoro.go
+++ b/internal/database/pomodoro.go
@@ -95,12 +95,15 @@ package database
 import (
 	"database/sql"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type Pomodoro struct {
 	Model
 
-	StartTime time.Time
-	EndTime   sql.NullTime
-	Completed bool
+	ActivityID uuid.UUID `gorm:"index"`
+	StartTime  time.Time
+	EndTime    sql.NullTime
+	Completed  bool
 }


### PR DESCRIPTION
I created a one-to-many relationship between Activity and Pomodoro. I updated the `pomorodo start` command to accept an activity ID either as a positional argument or by reading the activity ID from stdin. Reading from stdin allows for command line chaining where a previous command can output an activity ID and it can be piped into the `pomodoro start` command.

Closes #39 